### PR TITLE
Added installation for python-yaml

### DIFF
--- a/generate_config.py
+++ b/generate_config.py
@@ -2,6 +2,11 @@
 import binascii
 import yaml
 import os
+import platform
+
+if "Ubuntu" in platform.dist()[0]:
+	if "16.04" in platfrom.dist()[1]:
+		os.system("sudo apt install python-yaml")
 
 nginx_template = """
 server {


### PR DESCRIPTION
On Ubuntu 16.04 LTS python-yaml is not installed, so I added a few lines to help automate the installation of the project. If this gets accepted I can add more distros (e.g not "apt-get" ones) if needed.