### PR TITLE
Disabled self-registration. Ensured API and GUI server start on local…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@ api/uploads/*
 api/logs/*
 gui/guienv/*
 *.pyc
-.DS_Store
-api/uploads/*
+**/.DS_Store
+**/config.yaml
 env

--- a/api/apiserver.py
+++ b/api/apiserver.py
@@ -656,24 +656,43 @@ class DeleteCollectedPageHandler(BaseHandler):
         })
 
 def make_app():
-    return tornado.web.Application([
-        (r"/api/register", RegisterHandler),
-        (r"/api/login", LoginHandler),
-        (r"/api/collected_pages", GetCollectedPagesHandler),
-        (r"/api/delete_injection", DeleteInjectionHandler),
-        (r"/api/delete_collected_page", DeleteCollectedPageHandler),
-        (r"/api/user", UserInformationHandler),
-        (r"/api/payloadfires", GetXSSPayloadFiresHandler),
-        (r"/api/contactus", ContactUsHandler),
-        (r"/api/resend_injection_email", ResendInjectionEmailHandler),
-        (r"/api/logout", LogoutHandler),
-        (r"/js_callback", CallbackHandler),
-        (r"/page_callback", CollectPageHandler),
-        (r"/health", HealthHandler),
-        (r"/uploads/(.*)", tornado.web.StaticFileHandler, {"path": "uploads/"}),
-        (r"/api/record_injection", InjectionRequestHandler),
-        (r"/(.*)", HomepageHandler),
-    ], cookie_secret=settings["cookie_secret"])
+    if settings['self_registration'] == "yes":
+        return tornado.web.Application([
+            (r"/api/register", RegisterHandler),
+            (r"/api/login", LoginHandler),
+            (r"/api/collected_pages", GetCollectedPagesHandler),
+            (r"/api/delete_injection", DeleteInjectionHandler),
+            (r"/api/delete_collected_page", DeleteCollectedPageHandler),
+            (r"/api/user", UserInformationHandler),
+            (r"/api/payloadfires", GetXSSPayloadFiresHandler),
+            (r"/api/contactus", ContactUsHandler),
+            (r"/api/resend_injection_email", ResendInjectionEmailHandler),
+            (r"/api/logout", LogoutHandler),
+            (r"/js_callback", CallbackHandler),
+            (r"/page_callback", CollectPageHandler),
+            (r"/health", HealthHandler),
+            (r"/uploads/(.*)", tornado.web.StaticFileHandler, {"path": "uploads/"}),
+            (r"/api/record_injection", InjectionRequestHandler),
+            (r"/(.*)", HomepageHandler),
+        ], cookie_secret=settings["cookie_secret"])
+    else: # Self registration is disabled; don't add the route to the application
+        return tornado.web.Application([
+            (r"/api/login", LoginHandler),
+            (r"/api/collected_pages", GetCollectedPagesHandler),
+            (r"/api/delete_injection", DeleteInjectionHandler),
+            (r"/api/delete_collected_page", DeleteCollectedPageHandler),
+            (r"/api/user", UserInformationHandler),
+            (r"/api/payloadfires", GetXSSPayloadFiresHandler),
+            (r"/api/contactus", ContactUsHandler),
+            (r"/api/resend_injection_email", ResendInjectionEmailHandler),
+            (r"/api/logout", LogoutHandler),
+            (r"/js_callback", CallbackHandler),
+            (r"/page_callback", CollectPageHandler),
+            (r"/health", HealthHandler),
+            (r"/uploads/(.*)", tornado.web.StaticFileHandler, {"path": "uploads/"}),
+            (r"/api/record_injection", InjectionRequestHandler),
+            (r"/(.*)", HomepageHandler),
+        ], cookie_secret=settings["cookie_secret"])
 
 if __name__ == "__main__":
     args = sys.argv
@@ -681,5 +700,5 @@ if __name__ == "__main__":
     tornado.options.parse_command_line(args)
     Base.metadata.create_all(engine)
     app = make_app()
-    app.listen( 8888 )
+    app.listen( 8888, "localhost")
     tornado.ioloop.IOLoop.current().start()

--- a/generate_config.py
+++ b/generate_config.py
@@ -99,6 +99,7 @@ settings = {
     "domain": "",
     "abuse_email": "",
     "cookie_secret": "",
+    "self_registration": "yes",
 }
 
 print """
@@ -172,6 +173,9 @@ sudo cp default /etc/nginx/sites-enabled/default
 Also, please ensure your wildcard SSL certificate and key are available at the following locations:
 /etc/nginx/ssl/""" + hostname + """.crt; # Wildcard SSL certificate
 /etc/nginx/ssl/""" + hostname + """.key; # Wildcard SSL key
+
+Note: by default self-registration is enabled. You can disable this by changing the 'self_registration' option in the config file to 
+"no".
 
 Good luck hunting for XSS!
 							-mandatory

--- a/gui/guiserver.py
+++ b/gui/guiserver.py
@@ -54,18 +54,27 @@ class ContactHandler(BaseHandler):
         self.write( loader.load( "contact.htm" ).generate() )
 
 def make_app():
-    return tornado.web.Application([
-        (r"/", HomepageHandler),
-        (r"/app", XSSHunterApplicationHandler),
-        (r"/features", FeaturesHandler),
-        (r"/signup", SignUpHandler),
-        (r"/contact", ContactHandler),
-        (r"/static/(.*)", tornado.web.StaticFileHandler, {"path": "static/"}),
-    ])
+    if settings['self_registration'] == "yes":
+        return tornado.web.Application([
+            (r"/", HomepageHandler),
+            (r"/app", XSSHunterApplicationHandler),
+            (r"/features", FeaturesHandler),
+            (r"/signup", SignUpHandler),
+            (r"/contact", ContactHandler),
+            (r"/static/(.*)", tornado.web.StaticFileHandler, {"path": "static/"}),
+        ])
+    else:
+        return tornado.web.Application([
+            (r"/", HomepageHandler),
+            (r"/app", XSSHunterApplicationHandler),
+            (r"/features", FeaturesHandler),
+            (r"/contact", ContactHandler),
+            (r"/static/(.*)", tornado.web.StaticFileHandler, {"path": "static/"}),
+        ])
 
 if __name__ == "__main__":
     DOMAIN = settings["domain"]
     API_SERVER = "https://api." + DOMAIN
     app = make_app()
-    app.listen( 1234 )
+    app.listen( 1234, "localhost")
     tornado.ioloop.IOLoop.current().start()


### PR DESCRIPTION
…host (rather than 0.0.0.0)

1. Added configuration option to disable self-registration. Some users might not want randoms to be able to register accounts on their private XSSHunter instances.
2. Modified the API and GUI servers to listen on localhost rather than 0.0.0.0. The nginx server handles proxying to these endpoints anyway, so there's no need for them to be publicly accessible.
3. Updated .gitignore to prevent people from committing config.yaml :P