### PR TITLE
Self-Registration config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@ api/uploads/*
 api/logs/*
 gui/guienv/*
 *.pyc
-.DS_Store
-api/uploads/*
+**/.DS_Store
+**/config.yaml
 env

--- a/api/apiserver.py
+++ b/api/apiserver.py
@@ -656,9 +656,7 @@ class DeleteCollectedPageHandler(BaseHandler):
         })
 
 def make_app():
-    if settings['self_registration'] == "yes":
-        return tornado.web.Application([
-            (r"/api/register", RegisterHandler),
+    app_routes = [
             (r"/api/login", LoginHandler),
             (r"/api/collected_pages", GetCollectedPagesHandler),
             (r"/api/delete_injection", DeleteInjectionHandler),
@@ -674,25 +672,10 @@ def make_app():
             (r"/uploads/(.*)", tornado.web.StaticFileHandler, {"path": "uploads/"}),
             (r"/api/record_injection", InjectionRequestHandler),
             (r"/(.*)", HomepageHandler),
-        ], cookie_secret=settings["cookie_secret"])
-    else: # Self registration is disabled; don't add the route to the application
-        return tornado.web.Application([
-            (r"/api/login", LoginHandler),
-            (r"/api/collected_pages", GetCollectedPagesHandler),
-            (r"/api/delete_injection", DeleteInjectionHandler),
-            (r"/api/delete_collected_page", DeleteCollectedPageHandler),
-            (r"/api/user", UserInformationHandler),
-            (r"/api/payloadfires", GetXSSPayloadFiresHandler),
-            (r"/api/contactus", ContactUsHandler),
-            (r"/api/resend_injection_email", ResendInjectionEmailHandler),
-            (r"/api/logout", LogoutHandler),
-            (r"/js_callback", CallbackHandler),
-            (r"/page_callback", CollectPageHandler),
-            (r"/health", HealthHandler),
-            (r"/uploads/(.*)", tornado.web.StaticFileHandler, {"path": "uploads/"}),
-            (r"/api/record_injection", InjectionRequestHandler),
-            (r"/(.*)", HomepageHandler),
-        ], cookie_secret=settings["cookie_secret"])
+        ]
+    if settings['self_registration']:
+        app_routes.append((r"/api/register", RegisterHandler))  
+    return tornado.web.Application(app_routes, cookie_secret=settings["cookie_secret"])
 
 if __name__ == "__main__":
     args = sys.argv

--- a/api/apiserver.py
+++ b/api/apiserver.py
@@ -656,24 +656,43 @@ class DeleteCollectedPageHandler(BaseHandler):
         })
 
 def make_app():
-    return tornado.web.Application([
-        (r"/api/register", RegisterHandler),
-        (r"/api/login", LoginHandler),
-        (r"/api/collected_pages", GetCollectedPagesHandler),
-        (r"/api/delete_injection", DeleteInjectionHandler),
-        (r"/api/delete_collected_page", DeleteCollectedPageHandler),
-        (r"/api/user", UserInformationHandler),
-        (r"/api/payloadfires", GetXSSPayloadFiresHandler),
-        (r"/api/contactus", ContactUsHandler),
-        (r"/api/resend_injection_email", ResendInjectionEmailHandler),
-        (r"/api/logout", LogoutHandler),
-        (r"/js_callback", CallbackHandler),
-        (r"/page_callback", CollectPageHandler),
-        (r"/health", HealthHandler),
-        (r"/uploads/(.*)", tornado.web.StaticFileHandler, {"path": "uploads/"}),
-        (r"/api/record_injection", InjectionRequestHandler),
-        (r"/(.*)", HomepageHandler),
-    ], cookie_secret=settings["cookie_secret"])
+    if settings['self_registration'] == "yes":
+        return tornado.web.Application([
+            (r"/api/register", RegisterHandler),
+            (r"/api/login", LoginHandler),
+            (r"/api/collected_pages", GetCollectedPagesHandler),
+            (r"/api/delete_injection", DeleteInjectionHandler),
+            (r"/api/delete_collected_page", DeleteCollectedPageHandler),
+            (r"/api/user", UserInformationHandler),
+            (r"/api/payloadfires", GetXSSPayloadFiresHandler),
+            (r"/api/contactus", ContactUsHandler),
+            (r"/api/resend_injection_email", ResendInjectionEmailHandler),
+            (r"/api/logout", LogoutHandler),
+            (r"/js_callback", CallbackHandler),
+            (r"/page_callback", CollectPageHandler),
+            (r"/health", HealthHandler),
+            (r"/uploads/(.*)", tornado.web.StaticFileHandler, {"path": "uploads/"}),
+            (r"/api/record_injection", InjectionRequestHandler),
+            (r"/(.*)", HomepageHandler),
+        ], cookie_secret=settings["cookie_secret"])
+    else: # Self registration is disabled; don't add the route to the application
+        return tornado.web.Application([
+            (r"/api/login", LoginHandler),
+            (r"/api/collected_pages", GetCollectedPagesHandler),
+            (r"/api/delete_injection", DeleteInjectionHandler),
+            (r"/api/delete_collected_page", DeleteCollectedPageHandler),
+            (r"/api/user", UserInformationHandler),
+            (r"/api/payloadfires", GetXSSPayloadFiresHandler),
+            (r"/api/contactus", ContactUsHandler),
+            (r"/api/resend_injection_email", ResendInjectionEmailHandler),
+            (r"/api/logout", LogoutHandler),
+            (r"/js_callback", CallbackHandler),
+            (r"/page_callback", CollectPageHandler),
+            (r"/health", HealthHandler),
+            (r"/uploads/(.*)", tornado.web.StaticFileHandler, {"path": "uploads/"}),
+            (r"/api/record_injection", InjectionRequestHandler),
+            (r"/(.*)", HomepageHandler),
+        ], cookie_secret=settings["cookie_secret"])
 
 if __name__ == "__main__":
     args = sys.argv
@@ -681,5 +700,5 @@ if __name__ == "__main__":
     tornado.options.parse_command_line(args)
     Base.metadata.create_all(engine)
     app = make_app()
-    app.listen( 8888 )
+    app.listen( 8888, "localhost")
     tornado.ioloop.IOLoop.current().start()

--- a/api/apiserver.py
+++ b/api/apiserver.py
@@ -657,6 +657,7 @@ class DeleteCollectedPageHandler(BaseHandler):
 
 def make_app():
     app_routes = [
+            (r"/api/register", RegisterHandler),
             (r"/api/login", LoginHandler),
             (r"/api/collected_pages", GetCollectedPagesHandler),
             (r"/api/delete_injection", DeleteInjectionHandler),
@@ -671,10 +672,9 @@ def make_app():
             (r"/health", HealthHandler),
             (r"/uploads/(.*)", tornado.web.StaticFileHandler, {"path": "uploads/"}),
             (r"/api/record_injection", InjectionRequestHandler),
-            (r"/(.*)", HomepageHandler),
-        ]
-    if settings['self_registration']:
-        app_routes.append((r"/api/register", RegisterHandler))  
+            (r"/(.*)", HomepageHandler)]
+    if not settings['self_registration']:
+        app_routes.remove((r"/api/register", RegisterHandler))  
     return tornado.web.Application(app_routes, cookie_secret=settings["cookie_secret"])
 
 if __name__ == "__main__":

--- a/generate_config.py
+++ b/generate_config.py
@@ -99,6 +99,7 @@ settings = {
     "domain": "",
     "abuse_email": "",
     "cookie_secret": "",
+    "self_registration": "yes",
 }
 
 print """
@@ -172,6 +173,9 @@ sudo cp default /etc/nginx/sites-enabled/default
 Also, please ensure your wildcard SSL certificate and key are available at the following locations:
 /etc/nginx/ssl/""" + hostname + """.crt; # Wildcard SSL certificate
 /etc/nginx/ssl/""" + hostname + """.key; # Wildcard SSL key
+
+Note: by default self-registration is enabled. You can disable this by changing the 'self_registration' option in the config file to 
+"no".
 
 Good luck hunting for XSS!
 							-mandatory

--- a/gui/guiserver.py
+++ b/gui/guiserver.py
@@ -54,18 +54,27 @@ class ContactHandler(BaseHandler):
         self.write( loader.load( "contact.htm" ).generate() )
 
 def make_app():
-    return tornado.web.Application([
-        (r"/", HomepageHandler),
-        (r"/app", XSSHunterApplicationHandler),
-        (r"/features", FeaturesHandler),
-        (r"/signup", SignUpHandler),
-        (r"/contact", ContactHandler),
-        (r"/static/(.*)", tornado.web.StaticFileHandler, {"path": "static/"}),
-    ])
+    if settings['self_registration'] == "yes":
+        return tornado.web.Application([
+            (r"/", HomepageHandler),
+            (r"/app", XSSHunterApplicationHandler),
+            (r"/features", FeaturesHandler),
+            (r"/signup", SignUpHandler),
+            (r"/contact", ContactHandler),
+            (r"/static/(.*)", tornado.web.StaticFileHandler, {"path": "static/"}),
+        ])
+    else:
+        return tornado.web.Application([
+            (r"/", HomepageHandler),
+            (r"/app", XSSHunterApplicationHandler),
+            (r"/features", FeaturesHandler),
+            (r"/contact", ContactHandler),
+            (r"/static/(.*)", tornado.web.StaticFileHandler, {"path": "static/"}),
+        ])
 
 if __name__ == "__main__":
     DOMAIN = settings["domain"]
     API_SERVER = "https://api." + DOMAIN
     app = make_app()
-    app.listen( 1234 )
+    app.listen( 1234, "localhost")
     tornado.ioloop.IOLoop.current().start()

--- a/gui/guiserver.py
+++ b/gui/guiserver.py
@@ -54,23 +54,16 @@ class ContactHandler(BaseHandler):
         self.write( loader.load( "contact.htm" ).generate() )
 
 def make_app():
-    if settings['self_registration'] == "yes":
-        return tornado.web.Application([
-            (r"/", HomepageHandler),
-            (r"/app", XSSHunterApplicationHandler),
-            (r"/features", FeaturesHandler),
-            (r"/signup", SignUpHandler),
-            (r"/contact", ContactHandler),
-            (r"/static/(.*)", tornado.web.StaticFileHandler, {"path": "static/"}),
-        ])
-    else:
-        return tornado.web.Application([
+    app_routes = [
             (r"/", HomepageHandler),
             (r"/app", XSSHunterApplicationHandler),
             (r"/features", FeaturesHandler),
             (r"/contact", ContactHandler),
             (r"/static/(.*)", tornado.web.StaticFileHandler, {"path": "static/"}),
-        ])
+    ]
+    if settings['self_registration']:
+        app_routes.append((r"/signup", SignUpHandler))
+    return tornado.web.Application(app_routes)
 
 if __name__ == "__main__":
     DOMAIN = settings["domain"]

--- a/gui/guiserver.py
+++ b/gui/guiserver.py
@@ -59,10 +59,11 @@ def make_app():
             (r"/app", XSSHunterApplicationHandler),
             (r"/features", FeaturesHandler),
             (r"/contact", ContactHandler),
-            (r"/static/(.*)", tornado.web.StaticFileHandler, {"path": "static/"}),
+            (r"/signup", SignUpHandler),
+            (r"/static/(.*)", tornado.web.StaticFileHandler, {"path": "static/"})
     ]
-    if settings['self_registration']:
-        app_routes.append((r"/signup", SignUpHandler))
+    if not settings['self_registration']:
+        app_routes.remove((r"/signup", SignUpHandler))  
     return tornado.web.Application(app_routes)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added configuration option to enable/disable self-registration (requires restart of both api and gui servers).
Reconfigured API and GUI servers to listen only on localhost, rather than 0.0.0.0. (Nginx handles the app proxying to these servers anyway so there's no reason for them to be publicly accessible.)
Added some other entries to gitignore.
