### PR TITLE
Support using Mailgun's EU region

### DIFF
--- a/api/apiserver.py
+++ b/api/apiserver.py
@@ -230,6 +230,12 @@ def record_callback_in_database( callback_data, request_handler ):
 def email_sent_callback( response ):
     print response.body
 
+def mailgun_api_url( region ):
+    if region.lower() == "eu":
+        return "https://api.eu.mailgun.net/v3/"
+    else:
+        return "https://api.mailgun.net/v3/"
+
 def send_email( to, subject, body, attachment_file, body_type="html" ):
     if body_type == "html":
         body += "<br /><img src=\"https://api." + settings["domain"] + "/" + attachment_file.encode( "utf-8" ) + "\" />" # I'm so sorry.
@@ -241,7 +247,7 @@ def send_email( to, subject, body, attachment_file, body_type="html" ):
         body_type: urllib.quote_plus( body ),
     }
 
-    thread = unirest.post( "https://api.mailgun.net/v3/" + settings["mailgun_sending_domain"] + "/messages",
+    thread = unirest.post( mailgun_api_url( settings["mailgun_api_region"] ) + settings["mailgun_sending_domain"] + "/messages",
             headers={"Accept": "application/json"},
             params=email_data,
             auth=("api", settings["mailgun_api_key"] ),

--- a/generate_config.py
+++ b/generate_config.py
@@ -94,6 +94,7 @@ server {
 
 settings = {
     "email_from":"",
+    "mailgun_api_region":"",
     "mailgun_api_key":"",
     "mailgun_sending_domain":"",
     "domain": "",
@@ -125,6 +126,10 @@ print ""
 print "Enter your API key: "
 print "(ex. key-8da843ff65205a61374b09b81ed0fa35)"
 settings["mailgun_api_key"] = raw_input( "Mailgun API key: ")
+print ""
+print "What is your Mailgun region? "
+print "(ex. US or EU)"
+settings["mailgun_api_region"] = raw_input( "Mailgun region: ")
 print ""
 print "What is your Mailgun domain? "
 print "(ex. example.com)"


### PR DESCRIPTION
The application is currently hardcoding the Mailgun API URL, which prevents the email functionality from working for users who setup their email domain in the EU region.

This change makes it configurable.